### PR TITLE
Corrected id values during POST and PUT requests

### DIFF
--- a/lib/puppet/provider/graylog_api.rb
+++ b/lib/puppet/provider/graylog_api.rb
@@ -50,7 +50,7 @@ class Puppet::Provider::GraylogAPI < Puppet::Provider
           'Content-Type' => 'application/json',
           'X-Requested-By' => 'puppet',
         }
-        body = params.to_json
+        body = params.compact!().to_json
         query = nil
       end
       begin

--- a/lib/puppet/provider/graylog_api.rb
+++ b/lib/puppet/provider/graylog_api.rb
@@ -179,14 +179,17 @@ class Puppet::Provider::GraylogAPI < Puppet::Provider
   end
 
   def simple_flush(path,params)
-    params = recursive_undef_to_nil(params)
     case @action
     when :destroy
       delete("#{path}/#{rest_id}")
     when :create
+      params.[]=(:id,nil)
+      params = recursive_undef_to_nil(params)
       response = post("#{path}",params)
       set_rest_id_on_create(response) if respond_to?(:set_rest_id_on_create)
     else
+      params.[]=(:id,rest_id)
+      params = recursive_undef_to_nil(params)
       put("#{path}/#{rest_id}",params)
     end
   end


### PR DESCRIPTION
During create operations, an id value was being provided (the id field was erroneously being assigned from the name of the resource). This was resulting in an invalid reference server side. => Fix was a little hacky. I forced the ID param to nil during create operations before sending (didn't want to accidentally break something else that was depending on the name/ID fallback)

During update operations the difference between the url path ID parameter and the body json ID was causing an error in the server API (I didn't examine the raw request so it may be a typing error from puppet where the ID value was being specified as null or "" in the request rather than omitted). => Fix was to explicitly specify the ID param in the body content to match the url path param.
I'm a novice at Ruby so feel free to suggest improvements.