### PR TITLE
Make retries.rb like all others

### DIFF
--- a/lib/puppet/feature/retries.rb
+++ b/lib/puppet/feature/retries.rb
@@ -1,1 +1,3 @@
-Puppet.features.add(:retries, libs: ["retries"])
+require 'puppet/util/feature'
+
+Puppet.features.add(:retries, libs: 'retries')


### PR DESCRIPTION
I did a quick search on github and looks like nearly all puppet modules use this exact file.

This will prevent weird flapping changes on retries.rb when you use another module with retries.rb in it.